### PR TITLE
Support other try types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,4 @@ repository = "https://github.com/withoutboats/fehler"
 path = "./fehler-macros"
 version = "1.0.0-alpha.2"
 
-[features]
-nightly = []
-
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,7 @@ repository = "https://github.com/withoutboats/fehler"
 path = "./fehler-macros"
 version = "1.0.0-alpha.2"
 
+[features]
+nightly = []
+
 [workspace]

--- a/fehler-macros/Cargo.toml
+++ b/fehler-macros/Cargo.toml
@@ -16,5 +16,5 @@ quote = "1.0.0"
 proc-macro2 = "1.0.0"
 
 [dependencies.syn]
-features = ["default", "fold", "full"]
+features = ["default", "fold", "full", "parsing"]
 version = "1.0.0"

--- a/fehler-macros/src/args.rs
+++ b/fehler-macros/src/args.rs
@@ -52,6 +52,13 @@ impl Args {
 
 impl Parse for Args {
     fn parse(input: ParseStream) -> Result<Args> {
+        if input.is_empty() {
+            return Ok(Args {
+                error: Some(default_error()),
+                wrapper: Some(result()),
+            })
+        }
+
         let error = match input.peek(Token![as]) {
             true    => None,
             false   => {
@@ -102,5 +109,5 @@ fn result() -> Type {
 }
 
 fn default_error() -> Type {
-    syn::parse_str("crate::Error").unwrap()
+    syn::parse_str("Error").unwrap()
 }

--- a/fehler-macros/src/args.rs
+++ b/fehler-macros/src/args.rs
@@ -1,0 +1,106 @@
+// The Args type parses the arguments to the `#[throws]` macro.
+//
+// It is also responsible for transforming the return type by injecting
+// the return type and the error type into the wrapper type.
+
+use proc_macro2::Span;
+use syn::{GenericArgument, Path, PathArguments, ReturnType, Token, Type};
+use syn::parse::*;
+
+const WRAPPER_MUST_BE_PATH: &str = "Wrapper type must be a normal path type";
+
+pub struct Args {
+    error: Option<Type>,
+    wrapper: Option<Type>,
+}
+
+impl Args {
+    pub fn ret(&mut self, ret: ReturnType) -> ReturnType {
+        let (arrow, ret) = match ret {
+            ReturnType::Default         => (arrow(), unit()),
+            ReturnType::Type(arrow, ty) => (arrow, *ty),
+        };
+        ReturnType::Type(arrow, Box::new(self.inject_to_wrapper(ret)))
+
+    }
+
+    fn inject_to_wrapper(&mut self, ret: Type) -> Type {
+        if let Some(Type::Path(mut wrapper)) = self.wrapper.take() {
+            let types = if let Some(error) = self.error.take() {
+                vec![ret, error].into_iter().map(GenericArgument::Type)
+            } else {
+                vec![ret].into_iter().map(GenericArgument::Type)
+            };
+
+            match innermost_path_arguments(&mut wrapper.path) {
+                args @ &mut PathArguments::None    => {
+                    *args = PathArguments::AngleBracketed(syn::AngleBracketedGenericArguments {
+                        colon2_token: None,
+                        lt_token: Token![<](Span::call_site()),
+                        args: types.collect(),
+                        gt_token: Token![>](Span::call_site()),
+                    });
+                }
+                PathArguments::AngleBracketed(args) => args.args.extend(types),
+                _   => panic!(WRAPPER_MUST_BE_PATH)
+            }
+
+            Type::Path(wrapper)
+        } else { panic!(WRAPPER_MUST_BE_PATH) }
+    }
+}
+
+impl Parse for Args {
+    fn parse(input: ParseStream) -> Result<Args> {
+        let error = match input.peek(Token![as]) {
+            true    => None,
+            false   => {
+                let error = input.parse()?;
+                Some(match error {
+                    Type::Infer(_)  => default_error(),
+                    _               => error,
+                })
+            }
+        };
+
+        let wrapper = Some(match input.parse::<Token![as]>().is_ok() {
+            true    => input.parse()?,
+            false   => result(),
+        });
+
+        Ok(Args { error, wrapper })
+    }
+}
+
+fn innermost_path_arguments(path: &mut Path) -> &mut PathArguments {
+    let arguments = &mut path.segments.last_mut().expect(WRAPPER_MUST_BE_PATH).arguments;
+    match arguments {
+        PathArguments::None                 => arguments,
+        PathArguments::AngleBracketed(args) => {
+            match args.args.last_mut() {
+                Some(GenericArgument::Type(Type::Path(inner)))  => {
+                    innermost_path_arguments(&mut inner.path)
+                }
+                // Bizarre cases like `#[throw(_ as MyTryType<'a>)]` just not supported currently
+                _   => panic!("Certain strange wrapper types not supported"),
+            }
+        }
+        _                                   => panic!(WRAPPER_MUST_BE_PATH)
+    }
+}
+
+fn arrow() -> syn::token::RArrow {
+    Token![->](Span::call_site())
+}
+
+fn unit() -> Type {
+    syn::parse_str("()").unwrap()
+}
+
+fn result() -> Type {
+    syn::parse_str("::core::result::Result").unwrap()
+}
+
+fn default_error() -> Type {
+    syn::parse_str("crate::Error").unwrap()
+}

--- a/fehler-macros/src/lib.rs
+++ b/fehler-macros/src/lib.rs
@@ -1,10 +1,15 @@
 extern crate proc_macro;
 
+mod args;
 mod throws;
 
 use proc_macro::*;
 
+use args::Args;
+use throws::Throws;
+
 #[proc_macro_attribute]
 pub fn throws(args: TokenStream, input: TokenStream) -> TokenStream {
-    crate::throws::entry(args, input)
+    let args = syn::parse_macro_input!(args as Args);
+    Throws::new(args).fold(input)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,35 +1,92 @@
 #![no_std]
-#![cfg_attr(feature = "nightly", feature(try_trait))]
 #[doc(inline)]
 /// Annotations a function that "throws" a Result.
 ///
 /// Inside functions tagged with `throws`, you can use `?` and the `throw!` macro to return errors,
 /// but you don't need to wrap the successful return values in `Ok`.
 ///
-/// `throws` can optionally take a type as an argument, which will be the error type returned by
-/// this function. By default, the function will throw this crate's "default error type." (see
-/// below).
+/// Using this syntax, you can write fallible functions almost as if they were nonfallible. Every
+/// time a function call would return a `Result`, you "re-raise" the error using `?`, and if you
+/// wish to raise your own error, you can return it with the `throw!` macro.
+///
+/// ## Example
+/// ```should_panic
+/// use std::io::{self, Read};
+///
+/// use fehler::{throw, throws};
+///
+/// #[throws(io::Error)]
+/// fn main() {
+///     let mut file = std::fs::File::open("The_House_of_the_Spirits.txt")?;
+///     let mut text = String::new();
+///     file.read_to_string(&mut text)?;
+///
+///     if !text.starts_with("Barrabas came to us by sea, the child Clara wrote") {
+///         throw!(io::Error::from_raw_os_error(22));
+///     }
+///
+///     println!("Okay!");
+/// }
+/// ```
 ///
 /// # Default Error Type
 ///
-/// This macro supports a "default error type," if you give the macro `_` instead of a type name.
-/// The default error type will be whatever the path `crate::Error` resolves to: so if you have
-/// a type called `Error` in your crate root, that is the type the macro will use by default.
+/// This macro supports a "default error type" - if you do not pass a type to the macro, it will
+/// use the type named `Error` in this scope. So if you have defined an error type in this
+/// module, that will be the error thrown by this function.
 ///
-/// You can define your own error in your crate root, or you can use a type alias.
+/// You can access this feature by omitting the arguments entirely or by passing `_` as the type.
 ///
-/// # Example
+/// ## Example
 ///
 /// ```should_panic
-/// // Set the default error type for this crate:
+/// use fehler::throws;
+///
+/// // Set the default error type for this module:
 /// type Error = std::io::Error;
 ///
-/// #[fehler::throws(_)]
+/// #[throws]
 /// fn main() {
 ///    let file = std::fs::read_to_string("my_file.txt")?;
 ///    println!("{}", file);
 /// }
 /// ```
+///
+/// # Throwing as an Option
+///
+/// This syntax can also support functions which return an `Option` instead of a `Result`. The
+/// way to access this is to pass `as Option` as the argument to `throw`.
+///
+/// In functions that return `Option`, you can use the `throw!()` macro without any argument to
+/// return `None`.
+///
+/// ## Example
+///
+/// ```
+/// use fehler::{throw, throws};
+///
+/// #[throws(as Option)]
+/// fn example<T: Eq + Ord>(slice: &[T], needle: &T) -> usize {
+///     if !slice.contains(needle) {
+///         throw!();
+///     }
+///     slice.binary_search(needle).ok()?
+/// }
+/// ```
+///
+/// # Other `Try` types
+///
+/// The `?` syntax in Rust is controlled by a trait called `Try`, which is currently unstable.
+/// Because this feature is unstable and I don't want to maintain compatibility if its interface
+/// changes, this crate currently only works with two stable `Try` types: Result and Option.
+/// However, its designed so that it will hopefully support other `Try` types as well in the
+/// future.
+///
+/// It's worth noting that `Try` also has some other stable implementations: specifically `Poll`.
+/// Because of the somewhat unusual implementation of `Try` for those types, this crate does not
+/// support `throws` syntax on functions that return `Poll` (so you can't use this syntax when
+/// implementing a Future by hand, for example). I hope to come up with a way to support Poll in
+/// the future.
 pub use fehler_macros::throws;
 
 /// Throw an error.
@@ -53,7 +110,6 @@ pub mod __internal {
         fn from_error(error: Self::Error) -> Self;
     }
 
-    #[cfg(not(feature = "nightly"))]
     mod stable {
         use core::task::Poll;
 
@@ -115,27 +171,6 @@ pub mod __internal {
 
             fn from_ok(ok: Self::Ok) -> Self {
                 Some(ok)
-            }
-        }
-    }
-
-    #[cfg(feature = "nightly")]
-    mod nightly {
-        use core::ops::Try;
-
-        impl<T> super::_Succeed for T where T: Try {
-            type Ok = <T as Try>::Ok;
-
-            fn from_ok(ok: Self::Ok) -> Self {
-                <T as Try>::from_ok(ok)
-            }
-        }
-
-        impl<T> super::_Throw for T where T: Try {
-            type Error = <T as Try>::Error;
-
-            fn from_error(error: Self::Error) -> Self {
-                <T as Try>::from_error(error)
             }
         }
     }

--- a/tests/option.rs
+++ b/tests/option.rs
@@ -1,0 +1,17 @@
+use fehler::*;
+
+#[throws(as Option)]
+fn foo(x: bool) -> i32 {
+    if x { throw!(); }
+    0
+}
+
+#[test]
+fn test_outcome_true() {
+    assert!(foo(true).is_none())
+}
+
+#[test]
+fn test_outcome_false() {
+    assert_eq!(Some(0), foo(false))
+}

--- a/tests/throws.rs
+++ b/tests/throws.rs
@@ -87,3 +87,17 @@ pub fn throws_as_result() -> i32 {
 pub fn throws_as_result_alias() -> i32 {
     0
 }
+
+#[throws]
+pub fn ommitted_error() { }
+
+mod foo {
+    use fehler::*;
+
+    type Error = i32;
+
+    #[throws]
+    fn throws_integer() {
+        throw!(0);
+    }
+}

--- a/tests/throws.rs
+++ b/tests/throws.rs
@@ -77,3 +77,13 @@ pub async fn has_inner_async_block() {
     let f = async { 0 };
     let _: i32 = f.await;
 }
+
+#[throws(_ as Result)]
+pub fn throws_as_result() -> i32 {
+    0
+}
+
+#[throws(as std::io::Result)]
+pub fn throws_as_result_alias() -> i32 {
+    0
+}


### PR DESCRIPTION
Closes #27

The `throws` macro now takes an optional `as TYPE` argument. If this is
present, instead of transforming the return type to `Result`, it transforms it
to `TYPE` parameterized by the return and error types.

The error type is optional as well: if no error type is present, the wrapper
type is parameterized only by the return type.

This allows you to write `#[throws(as Option)]` to make a throwing function
that returns an option.

It also supports other try types.

Syntactically, these two should both work and be equivalent:
`#[throws(io::Error as Poll<Result>)]`
`#[throws(as Poll<io::Result>)]`

However, these do not work because of the way the return type needs to be
wrapped in poll. More thought needs to go into how to support the Poll types.