### PR TITLE
README: Remove explicit "return" from "Option" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The attribute can be used to make a function that returns an Option using the
 #[throws(as Option)]
 fn foo(x: bool) -> i32 {
     if x {
-        return 0;
+        0
     } else {
         throw!();
     }


### PR DESCRIPTION
I might be missing something, but isn't that `return` unnecessary?

Since this is one of the differences between the `Result` and the `Option` example, it might imply to some readers that the `Option` case only works with implicit returns?

Or is there a reason to use `return` in one example but not in the other?